### PR TITLE
feat: Добавление типа кнопки `text`

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -94,3 +94,25 @@
     fill: var(--WHITE);
   }
 }
+
+.text {
+  padding: 0;
+  color: var(--BLACK);
+  background-color: transparent;
+
+  svg {
+    fill: var(--BLACK);
+  }
+
+  &:hover {
+    background-color: transparent;
+  }
+
+  &Danger {
+    color: var(--RED-5);
+
+    svg {
+      fill: var(--RED-5);
+    }
+  }
+}

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import Button from "./Button";
+import { ButtonType } from './Button'
 
 export default {
   title: "React-UI/Button",
@@ -11,10 +12,8 @@ export default {
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 
 export const Default = Template.bind({});
-export const Disabled = Template.bind({});
-export const Loading = Template.bind({});
-export const Icon = Template.bind({});
-export const Danger = Template.bind({})
+export const Danger = Template.bind({});
+export const Text = Template.bind({});
 
 Default.args = {
   label: "Button",
@@ -23,29 +22,19 @@ Default.args = {
   icon: undefined
 };
 
-Disabled.args = {
-  label: "Disabled",
-  isDisabled: false,
-  isLoading: false,
-}
-
-Loading.args = {
-  label: "Loaded",
-  isLoading: true,
-  isDisabled: false,
-};
-
-Icon.args = {
-  label: "Button + Icon",
-  isLoading: false,
-  isDisabled: false,
-  icon: "Settings"
-}
-
 Danger.args = {
   label: "Button + Icon",
   isLoading: false,
   isDisabled: false,
   icon: "Settings",
   isDanger: true,
+}
+
+Text.args = {
+  label: "Text button",
+  isLoading: false,
+  isDisabled: false,
+  icon: 'Settings',
+  isDanger: false,
+  type: ButtonType.TEXT,
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,39 +7,52 @@ import { LoaderWrapper } from "./partials/loader-wrapper";
 
 import styles from './Button.module.scss'
 
+export enum ButtonType {
+  TEXT = 'text',
+  NONE = 'none',
+}
+
 export interface ButtonProps extends Pick<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'> {
   label: string;
   icon?: IconNames
   isDisabled?: boolean;
   isLoading?: boolean;
   isDanger?: boolean
+  type?: ButtonType
 }
 
 const Button = ({
   label,
   icon,
+  type = ButtonType.NONE,
   isDisabled = false,
   isLoading = false,
   isDanger = false,
   onClick = () => { },
-}: ButtonProps) => (
-  <button
-    className={cx(styles.button, {
-      [styles.buttonLoading]: isLoading,
-      [styles.buttonDisabled]: isLoading,
-      [styles.buttonDanger]: isDanger,
-    })}
-    onClick={onClick}
-    disabled={isDisabled}
-  >
-    {isLoading && (
-      <LoaderWrapper />
-    )}
-    {icon && (
-      <Icon icon={icon} />
-    )}
-    {label}
-  </button>
-)
+}: ButtonProps) => {
+  const isText = type === 'text'
+
+  return (
+    <button
+      className={cx(styles.button, {
+        [styles.buttonLoading]: isLoading,
+        [styles.buttonDisabled]: isLoading,
+        [styles.buttonDanger]: isDanger,
+        [styles.text]: isText,
+        [styles.textDanger]: isText && isDanger,
+      })}
+      onClick={onClick}
+      disabled={isDisabled}
+    >
+      {isLoading && (
+        <LoaderWrapper />
+      )}
+      {icon && (
+        <Icon icon={icon} />
+      )}
+      {label}
+    </button>
+  )
+}
 
 export default Button;


### PR DESCRIPTION
Добавлен тип кнопки текст, который убирает все стили у кнопки и делает как обычный текст, при этом весь функционал кнопки сохранен